### PR TITLE
Macrostrat map compilations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   allowed, and one layer can sit at different priorities under different parents
 - Existing `composited_from` values are migrated on `create-tables` (array
   ordinality becomes priority) and the column is dropped
+- Add `IdentityStrategy.solves_composites` (default false) and
+  `dirty_layers_for()`, replacing `child_map_layers()` in `mark_surrounding_faces`:
+  a change in a layer now marks its composition parents dirty, so a composite
+  layer can be *solved* by dissolving rather than filled by overlay. Gated,
+  because a strategy without a meaningful `faces_are_joinable` would dissolve a
+  composite into a single face; the overlay remains for linework mode
 - Add `constraining_layers()`, replacing `parent_map_layers()` in the dissolve:
   a layer's barriers are now its ancestors *and* its composition closure, so a
   composite layer solved by dissolving cannot span a contact that exists in one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   allowed, and one layer can sit at different priorities under different parents
 - Existing `composited_from` values are migrated on `create-tables` (array
   ordinality becomes priority) and the column is dropped
+- Add `dissolve_groups()`: walks every dirty component in a layer server-side and
+  returns a bounded batch of them, replacing the caller's one-round-trip-per-face
+  loop. `_max_groups` preserves checkpointing, so `--incremental` is now expressed
+  as a batch size. `joinable_face_edges()` -- built for a whole-layer label
+  propagation that was never written, and never called -- is left in place but is
+  still not the path taken: per-component BFS is proportional to the component,
+  where label propagation would take as many passes as the graph is wide
+- Index the referencing side of `map_face`'s cascading foreign keys
+  (`face_identity.map_face`, `map_face.source_id`): PostgreSQL does not create
+  these, so every deleted face sequentially scanned both tables
 - Add `IdentityStrategy.solves_composites` (default false) and
   `dirty_layers_for()`, replacing `child_map_layers()` in `mark_surrounding_faces`:
   a change in a layer now marks its composition parents dirty, so a composite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## `[Unreleased]`
+
+- Replace `map_layer.composited_from integer[]` with a `map_layer_composition` linking
+  table carrying an explicit `priority` (higher wins), plus `is_composite_layer()`
+  and `composite_layer_members()` helpers
+- Membership is foreign-keyed and cycle-checked; single-member composites are now
+  allowed, and one layer can sit at different priorities under different parents
+- Existing `composited_from` values are migrated on `create-tables` (array
+  ordinality becomes priority) and the column is dropped
+- Add `constraining_layers()`, replacing `parent_map_layers()` in the dissolve:
+  a layer's barriers are now its ancestors *and* its composition closure, so a
+  composite layer solved by dissolving cannot span a contact that exists in one
+  of its members
+
 ## `[5.0.0]` - 2026-06-11
 
 - Switch to UV

--- a/mapboard/topology_manager/commands/update_composite_layers.py
+++ b/mapboard/topology_manager/commands/update_composite_layers.py
@@ -9,7 +9,7 @@ def update_composite_layers(ctx: TopologyContext):
     log.info("Updating composite layers")
     db = ctx.database
     layers = db.run_query(
-        "SELECT id FROM {data_schema}.map_layer WHERE composited_from IS NOT NULL"
+        "SELECT id FROM {data_schema}.map_layer WHERE {data_schema}.is_composite_layer(id)"
     ).scalars()
     for layer in layers:
         log.info("Updating composite layer %s", layer)
@@ -149,7 +149,7 @@ def add_composite_layer_types(db, map_layer: int, layers: list[int]):
 def get_composite_layers(db, map_layer: int) -> list[int]:
     """Get the list of composite layers that a given map layer is part of."""
     layers = db.run_query(
-        "SELECT composited_from FROM {data_schema}.map_layer WHERE id = :map_layer",
+        "SELECT {data_schema}.composite_layer_members(:map_layer)",
         dict(map_layer=map_layer),
     ).scalar()
     if layers is None:

--- a/mapboard/topology_manager/commands/update_faces/__init__.py
+++ b/mapboard/topology_manager/commands/update_faces/__init__.py
@@ -12,10 +12,9 @@ from rich.progress import Progress
 
 from ...config import TopologyContext, sql, get_context
 from .helpers import (
-    persist_map_face_updates,
+    dissolve_layer_groups,
     log,
-    FaceUpdateResult,
-    update_map_face,
+    persist_map_face_updates,
 )
 
 count_ = "SELECT count(*)::integer nfaces FROM {topo_schema}.dirty_face"
@@ -80,45 +79,40 @@ def update_faces(
         ", ".join(f"{k}: {v}" for k, v in ix.items() if v > 0),
     )
 
-    results = []
+    # Dissolve is driven layer by layer, in batches: the database walks each
+    # component and returns a batch of them in one round trip, then the batch is
+    # persisted -- which unmarks its faces, so the next call sees a smaller dirty
+    # set. `persist_interval` is the batch size. Previously this loop made one
+    # round trip per dirty face, which left the database idle waiting on the
+    # client for roughly a third of a bulk update.
+    niter = 0
+    # `incremental` still means "checkpoint as you go": it is the batch size that
+    # provides it now, so a non-incremental run simply takes every group at once.
+    batch_size = persist_interval if incremental else None
     with Progress() as progress:
         bar = progress.add_task("Updating faces", total=init_n_faces)
-        niter = 0
-        while len(dirty_faces) > 0:
-            log.info(
-                "%s dirty faces remaining",
-                len(dirty_faces),
-            )
-            prev_len = len(dirty_faces)
-            # Extract one face
-            face = dirty_faces.pop(0)
-
-            res = update_map_face(db, face)
-            results.append(res)
-
-            # Persist the updates if we've reached an interval
-            if niter % persist_interval == 0 and incremental:
+        for map_layer in sorted(map_layers):
+            remaining = n_dirty_faces(db, map_layer)
+            while remaining > 0:
+                results = dissolve_layer_groups(db, map_layer, max_groups=batch_size)
+                if not results:
+                    break
                 persist_map_face_updates(db, results)
-                results = []
+                niter += len(results)
 
-            # Filter dirty faces to remove the ones that have been dissolved into the current face
-            dirty_faces = [
-                d
-                for d in dirty_faces
-                if not (d.id in res.dissolved_faces and d.map_layer == res.map_layer)
-            ]
-            niter += 1
-
-            progress.update(bar, completed=init_n_faces - len(dirty_faces))
-            # Safety guard: if the list didn't shrink and nothing was dissolved, bail out
-            if len(dirty_faces) >= prev_len and len(res.dissolved_faces) == 0:
-                log.warning(
-                    "No progress made on dirty faces (possible infinite loop); breaking after %d iterations",
-                    niter,
+                prev, remaining = remaining, n_dirty_faces(db, map_layer)
+                progress.update(
+                    bar, completed=max(0, init_n_faces - n_dirty_faces(db))
                 )
-                break
-
-        persist_map_face_updates(db, results)
+                # A group that dissolves nothing leaves its faces marked, so
+                # without this the layer would loop forever.
+                if remaining >= prev:
+                    log.warning(
+                        "No progress on %d dirty faces in layer %s; moving on",
+                        remaining,
+                        map_layer,
+                    )
+                    break
 
     t1 = perf_counter()
     log.info(

--- a/mapboard/topology_manager/commands/update_faces/helpers.py
+++ b/mapboard/topology_manager/commands/update_faces/helpers.py
@@ -32,6 +32,33 @@ def update_map_face(db: Database, face) -> FaceUpdateResult:
     return _get_adjacent_faces_core(db, face_id, map_layer)
 
 
+def dissolve_layer_groups(
+    db: Database, map_layer: int, *, max_groups: int | None = None
+) -> list[FaceUpdateResult]:
+    """Dissolve up to `max_groups` components in a layer, in one round trip.
+
+    The per-face equivalent of this is `_get_adjacent_faces_core` called in a
+    loop; the work is identical, but the loop runs in the database rather than
+    across the wire.
+    """
+    rows = db.run_query(
+        "SELECT * FROM {topo_schema}.dissolve_groups(:map_layer, :barriers, :max_groups)",
+        dict(
+            map_layer=map_layer,
+            barriers=[],
+            max_groups=max_groups,
+        ),
+    ).all()
+    return [
+        FaceUpdateResult(
+            dissolved_faces=list(set(r.faces)),
+            existing_map_faces=list(r.existing_map_faces or []),
+            map_layer=r.map_layer,
+        )
+        for r in rows
+    ]
+
+
 def persist_map_face_updates(
     db: Database, updates: list[FaceUpdateResult], *, unmark_dirty: bool = True
 ):

--- a/mapboard/topology_manager/config.py
+++ b/mapboard/topology_manager/config.py
@@ -37,6 +37,14 @@ class IdentityStrategy:
     # Reserved: the SQL currently hardcodes "or"; "and" is for the future
     # direct-identity linework mode.
     combinator: str = "or"
+    # Whether a composite layer can be *solved* by dissolving, rather than filled
+    # by the painter's-algorithm overlay. True only when `faces_are_joinable` is
+    # meaningful and identity resolves across a layer's composition closure --
+    # the `search` strategy has neither, so it keeps the overlay. This gates
+    # whether a change in a layer marks its composition parents dirty: doing so
+    # for a strategy that cannot solve them would dissolve a composite into one
+    # face.
+    solves_composites: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -154,6 +162,7 @@ def create_context(
         "boundary_table": Identifier(data_schema, boundary_table),
         "boundary_table_literal": Literal(boundary_table),
         "face_identity_column": Identifier(face_identity_column),
+        "solves_composites": SQL("true" if strategy.solves_composites else "false"),
     }
 
     ctx = TopologyContext(

--- a/mapboard/topology_manager/config.py
+++ b/mapboard/topology_manager/config.py
@@ -45,6 +45,13 @@ class IdentityStrategy:
     # for a strategy that cannot solve them would dissolve a composite into one
     # face.
     solves_composites: bool = False
+    # Whether the strategy installs `resolve_layer_identity(map_layer)` -- a
+    # set-oriented form of `identity_for_face` returning `(face_id, identity)` for
+    # a whole layer. When true, `dissolve_groups` materialises it once per layer
+    # and compares cached identities instead of calling `faces_are_joinable` on
+    # every candidate edge, which otherwise re-resolves each face's identity once
+    # per incident edge.
+    bulk_identity: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -163,6 +170,7 @@ def create_context(
         "boundary_table_literal": Literal(boundary_table),
         "face_identity_column": Identifier(face_identity_column),
         "solves_composites": SQL("true" if strategy.solves_composites else "false"),
+        "bulk_identity": SQL("true" if strategy.bulk_identity else "false"),
     }
 
     ctx = TopologyContext(

--- a/mapboard/topology_manager/fixtures/00.1-map-layers.sql
+++ b/mapboard/topology_manager/fixtures/00.1-map-layers.sql
@@ -10,50 +10,156 @@ CREATE TABLE IF NOT EXISTS {data_schema}.map_layer (
     description text,
     parent integer CHECK (id != parent) REFERENCES {data_schema}.map_layer(id),
     topological boolean DEFAULT false,
-    editable boolean DEFAULT true,
-    composited_from integer[]
+    editable boolean DEFAULT true
     -- Ideas for future functionality:
     -- simplified boolean DEFAULT false,
     -- derived_from integer[],
 );
 
-/** Trigger for composite layer constraints */
--- Check that all layers in composited_from exist.
--- This is in lieu of having a foreign key constraint on map_layer.composited_from
-CREATE OR REPLACE FUNCTION {data_schema}.check_composited_from()
+/**
+  COMPOSITE LAYER MEMBERSHIP
+
+  A composite layer draws its content from other layers. This table replaces the
+  former `map_layer.composited_from integer[]`, which could not carry a foreign
+  key (hence the hand-written existence trigger it needed) and encoded ordering
+  positionally.
+
+  `priority` is explicit and higher-wins: the member with the highest priority is
+  topmost in the composite. That is the same convention the array's order implied
+  -- last element painted last -- but stated rather than positional, and it gives
+  a place to hang a priority that is a property of the *relationship*, so one
+  layer can sit at different priorities under different parents.
+*/
+CREATE TABLE IF NOT EXISTS {data_schema}.map_layer_composition (
+    parent_id integer NOT NULL
+      REFERENCES {data_schema}.map_layer(id) ON DELETE CASCADE,
+    member_id integer NOT NULL
+      REFERENCES {data_schema}.map_layer(id) ON DELETE CASCADE,
+    priority integer NOT NULL,
+    PRIMARY KEY (parent_id, member_id),
+    CONSTRAINT map_layer_composition_no_self_reference CHECK (parent_id != member_id),
+    CONSTRAINT map_layer_composition_distinct_priority UNIQUE (parent_id, priority)
+      DEFERRABLE INITIALLY IMMEDIATE
+);
+
+CREATE INDEX IF NOT EXISTS map_layer_composition_member_idx
+  ON {data_schema}.map_layer_composition (member_id);
+
+/** Whether a layer draws its content from other layers. */
+CREATE OR REPLACE FUNCTION {data_schema}.is_composite_layer(_layer_id integer)
+  RETURNS boolean AS $$
+SELECT EXISTS (
+  SELECT 1 FROM {data_schema}.map_layer_composition WHERE parent_id = _layer_id
+);
+$$ LANGUAGE SQL STABLE;
+
+/** A composite layer's members, bottom-to-top (ascending priority).
+
+  This is the order the former `composited_from` array held, so callers that
+  paint in reverse keep working unchanged.
+*/
+CREATE OR REPLACE FUNCTION {data_schema}.composite_layer_members(_layer_id integer)
+  RETURNS integer[] AS $$
+SELECT array_agg(member_id ORDER BY priority)
+FROM {data_schema}.map_layer_composition
+WHERE parent_id = _layer_id;
+$$ LANGUAGE SQL STABLE;
+
+/** Composite layer constraints.
+
+  Enforced from both sides: adding a membership edge checks the parent, and
+  editing a layer that already has members checks that it stays valid. Unlike the
+  `composited_from` trigger this replaces, a single-member composite is allowed --
+  a compilation is legitimately built up one member at a time.
+*/
+CREATE OR REPLACE FUNCTION {data_schema}.check_map_layer_composition()
+  RETURNS trigger AS $$
+DECLARE
+  __parent {data_schema}.map_layer;
+BEGIN
+  SELECT * INTO __parent
+  FROM {data_schema}.map_layer
+  WHERE id = NEW.parent_id;
+
+  IF NOT coalesce(__parent.topological, false) THEN
+    RAISE EXCEPTION 'Composite layers must be topological';
+  END IF;
+
+  IF coalesce(__parent.editable, true) THEN
+    RAISE EXCEPTION 'Composite layers cannot be editable';
+  END IF;
+
+  -- Walk upwards from the parent; reaching the member would close a cycle.
+  -- The array form never checked this, but membership is now traversed
+  -- recursively, so a cycle is no longer merely wrong -- it fails to terminate.
+  IF EXISTS (
+    WITH RECURSIVE ancestors AS (
+      SELECT NEW.parent_id AS id
+      UNION
+      SELECT m.parent_id
+      FROM {data_schema}.map_layer_composition m
+      JOIN ancestors a ON m.member_id = a.id
+    )
+    SELECT 1 FROM ancestors WHERE id = NEW.member_id
+  ) THEN
+    RAISE EXCEPTION USING MESSAGE =
+      'Layer ' || NEW.parent_id || ' cannot composite from ' || NEW.member_id
+      || ' - that would create a cycle';
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE TRIGGER check_map_layer_composition_trigger
+  BEFORE INSERT OR UPDATE ON {data_schema}.map_layer_composition
+  FOR EACH ROW EXECUTE FUNCTION {data_schema}.check_map_layer_composition();
+
+CREATE OR REPLACE FUNCTION {data_schema}.check_composite_layer_flags()
   RETURNS trigger AS $$
 BEGIN
-  IF NEW.composited_from IS NOT NULL THEN
-    IF NOT NEW.topological THEN
-      RAISE EXCEPTION 'Composite layers must be topological';
-    END IF;
-
-    IF NEW.editable THEN
-      RAISE EXCEPTION 'Composite layers cannot be editable';
-    END IF;
-
-    IF cardinality(NEW.composited_from) < 2 THEN
-      RAISE EXCEPTION 'Composite layers must reference at least two other layers';
-    END IF;
-
-    -- Check if all referenced layers exist
-    IF EXISTS (
-      SELECT *
-      FROM unnest(NEW.composited_from)
-      EXCEPT
-      SELECT id
-      FROM {data_schema}.map_layer
-    ) THEN
-      RAISE EXCEPTION 'All layers in composited_from must exist';
-    END IF;
+  IF (coalesce(NEW.editable, true) OR NOT coalesce(NEW.topological, false))
+     AND {data_schema}.is_composite_layer(NEW.id)
+  THEN
+    RAISE EXCEPTION 'Composite layers must be topological and cannot be editable';
   END IF;
   RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
 
-CREATE TRIGGER check_composited_from_trigger
-  BEFORE INSERT OR UPDATE ON {data_schema}.map_layer
-  FOR EACH ROW EXECUTE FUNCTION {data_schema}.check_composited_from();
+CREATE OR REPLACE TRIGGER check_composite_layer_flags_trigger
+  BEFORE UPDATE ON {data_schema}.map_layer
+  FOR EACH ROW EXECUTE FUNCTION {data_schema}.check_composite_layer_flags();
+
+/** Migrate `composited_from` into the membership table, then retire the column.
+
+  Array ordinality becomes priority directly: the array ran bottom-to-top, so
+  ordinality 1 is the lowest priority. Guarded on the column's existence, so this
+  is a no-op on every run after the first.
+
+  TODO: create a migration script to handle this going forward.
+*/
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = {data_schema_name_literal}
+      AND table_name = 'map_layer'
+      AND column_name = 'composited_from'
+  ) THEN
+    INSERT INTO {data_schema}.map_layer_composition (parent_id, member_id, priority)
+    SELECT ml.id, m.member_id, m.ord
+    FROM {data_schema}.map_layer ml
+    CROSS JOIN LATERAL unnest(ml.composited_from) WITH ORDINALITY AS m(member_id, ord)
+    WHERE ml.composited_from IS NOT NULL
+    ON CONFLICT (parent_id, member_id) DO NOTHING;
+  END IF;
+END
+$$;
+
+DROP TRIGGER IF EXISTS check_composited_from_trigger ON {data_schema}.map_layer;
+DROP FUNCTION IF EXISTS {data_schema}.check_composited_from();
+ALTER TABLE {data_schema}.map_layer DROP COLUMN IF EXISTS composited_from;
 
 
 /** A view to summarize the tree of map layers */
@@ -109,4 +215,3 @@ SELECT
 FROM p1
 JOIN c1
   ON p1.map_layer = c1.map_layer;
-

--- a/mapboard/topology_manager/fixtures/00.2-topology-tables.sql
+++ b/mapboard/topology_manager/fixtures/00.2-topology-tables.sql
@@ -26,6 +26,10 @@ CREATE INDEX IF NOT EXISTS face_identity_map_face_idx
   ON {topo_schema}.face_identity (map_face);
 CREATE INDEX IF NOT EXISTS map_face_source_id_idx
   ON {topo_schema}.map_face (source_id);
+/* `map_id` is a foreign key too, and unindexed it forces a sequential scan of the
+   whole face table whenever faces are looked up by the map that owns them. */
+CREATE INDEX IF NOT EXISTS map_face_map_id_idx
+  ON {topo_schema}.map_face ({face_identity_column});
 CREATE INDEX map_face_gix ON {topo_schema}.map_face USING GIST (geometry);
 /* Dissolving a component looks up the map_faces it replaces by joining `relation`
    on the topogeometry id. A composite field access cannot use an ordinary index,

--- a/mapboard/topology_manager/fixtures/00.2-topology-tables.sql
+++ b/mapboard/topology_manager/fixtures/00.2-topology-tables.sql
@@ -18,6 +18,14 @@ CREATE TABLE IF NOT EXISTS {topo_schema}.face_identity (
   PRIMARY KEY (face_id, map_layer)
 );
 CREATE INDEX face_identity_ix ON {topo_schema}.face_identity (face_id);
+/* PostgreSQL does not index the *referencing* side of a foreign key, so without
+   these every `map_face` delete sequentially scans both tables to check its
+   `ON DELETE CASCADE` children -- ~23ms per deleted row on a real topology,
+   which dominates face replacement during an update. */
+CREATE INDEX IF NOT EXISTS face_identity_map_face_idx
+  ON {topo_schema}.face_identity (map_face);
+CREATE INDEX IF NOT EXISTS map_face_source_id_idx
+  ON {topo_schema}.map_face (source_id);
 CREATE INDEX map_face_gix ON {topo_schema}.map_face USING GIST (geometry);
 
 /* A table to hold dirty faces */

--- a/mapboard/topology_manager/fixtures/00.2-topology-tables.sql
+++ b/mapboard/topology_manager/fixtures/00.2-topology-tables.sql
@@ -27,6 +27,12 @@ CREATE INDEX IF NOT EXISTS face_identity_map_face_idx
 CREATE INDEX IF NOT EXISTS map_face_source_id_idx
   ON {topo_schema}.map_face (source_id);
 CREATE INDEX map_face_gix ON {topo_schema}.map_face USING GIST (geometry);
+/* Dissolving a component looks up the map_faces it replaces by joining `relation`
+   on the topogeometry id. A composite field access cannot use an ordinary index,
+   so without this every component sequentially scans `map_face`. Only `(topo).id`
+   is indexed -- `check_topogeom_topo` pins the layer, so it adds nothing. */
+CREATE INDEX IF NOT EXISTS map_face_topogeom_id_idx
+  ON {topo_schema}.map_face (((topo).id));
 
 /* A table to hold dirty faces */
 CREATE TABLE IF NOT EXISTS {topo_schema}.dirty_face (

--- a/mapboard/topology_manager/fixtures/01.1-data-tables.sql
+++ b/mapboard/topology_manager/fixtures/01.1-data-tables.sql
@@ -136,7 +136,10 @@ SELECT ml.id
 FROM {data_schema}.map_layer ml,
      {data_schema}.linework_type lt
 WHERE ml.id = $1.map_layer
-  AND ml.composited_from IS NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM {data_schema}.map_layer_composition m
+    WHERE m.parent_id = ml.id
+  )
   AND lt.id = $1.type
   AND coalesce(lt.topological, true)
   AND ml.topological;

--- a/mapboard/topology_manager/fixtures/03-topology-functions.sql
+++ b/mapboard/topology_manager/fixtures/03-topology-functions.sql
@@ -143,6 +143,50 @@ JOIN r
 SELECT id FROM r;
 $$ LANGUAGE SQL IMMUTABLE;
 
+/** Every layer whose boundaries constrain a dissolve of `_map_layer`.
+
+  Two relations feed this, and they run in opposite directions:
+
+  - `map_layer.parent` -- a child inherits its ancestors' linework as barriers.
+  - `map_layer_composition` -- a composite layer draws its content from its
+    members, so its faces must not span a contact that exists in one of them.
+
+  Both are "from the current layer, reach the next one", so a single recursive
+  walk over the union of the two edge sets covers them (and picks up the
+  ancestors of composition members, which constrain those members in turn).
+
+  Until composite layers are solved by dissolving rather than filled by overlay,
+  the composition half is inert: only composite layers have members, and those
+  are never passed to the dissolve.
+*/
+CREATE OR REPLACE FUNCTION {topo_schema}.constraining_layers(
+  _map_layer integer,
+  _topological boolean DEFAULT true
+)
+RETURNS setof integer AS $$
+WITH RECURSIVE edges AS (
+  SELECT id AS src, parent AS dst
+  FROM {data_schema}.map_layer
+  WHERE parent IS NOT NULL
+  UNION ALL
+  SELECT parent_id AS src, member_id AS dst
+  FROM {data_schema}.map_layer_composition
+), r AS (
+  SELECT id
+  FROM {data_schema}.map_layer
+  WHERE id = _map_layer
+    AND CASE WHEN _topological THEN topological ELSE true END
+  UNION
+  SELECT ml.id
+  FROM r
+  JOIN edges e ON e.src = r.id
+  JOIN {data_schema}.map_layer ml
+    ON ml.id = e.dst
+   AND CASE WHEN _topological THEN ml.topological ELSE true END
+)
+SELECT id FROM r;
+$$ LANGUAGE SQL IMMUTABLE;
+
 CREATE OR REPLACE FUNCTION {topo_schema}.child_map_layers(
   _map_layer integer,
   _topological boolean DEFAULT true

--- a/mapboard/topology_manager/fixtures/03-topology-functions.sql
+++ b/mapboard/topology_manager/fixtures/03-topology-functions.sql
@@ -210,3 +210,30 @@ JOIN r
 )
 SELECT id FROM r;
 $$ LANGUAGE SQL IMMUTABLE;
+
+/** Every layer whose faces a change in `_map_layer` invalidates.
+
+  Its tree children, which inherit its linework -- and, where composites are
+  *solved* rather than overlaid, the layers that composite from it, transitively.
+  Dirtiness propagates upward through composition, the mirror of how barriers
+  propagate downward in `constraining_layers`.
+
+  The composition half is gated on the identity strategy: marking a composite
+  dirty for a strategy that cannot resolve identity across its members would
+  dissolve the whole layer into a single face.
+*/
+CREATE OR REPLACE FUNCTION {topo_schema}.dirty_layers_for(_map_layer integer)
+RETURNS setof integer AS $$
+WITH RECURSIVE composite_parents AS (
+  SELECT _map_layer AS id
+  UNION
+  SELECT c.parent_id
+  FROM composite_parents p
+  JOIN {data_schema}.map_layer_composition c ON c.member_id = p.id
+  WHERE {solves_composites}
+)
+SELECT id FROM {topo_schema}.child_map_layers(_map_layer) AS t(id)
+UNION
+SELECT id FROM composite_parents;
+$$ LANGUAGE SQL;
+

--- a/mapboard/topology_manager/fixtures/05-linework-triggers.sql
+++ b/mapboard/topology_manager/fixtures/05-linework-triggers.sql
@@ -77,7 +77,7 @@ BEGIN
   INTO __faces;
 
   WITH ml AS (
-    SELECT {topo_schema}.child_map_layers(line.map_layer) id
+    SELECT {topo_schema}.dirty_layers_for(line.map_layer) id
   )
   INSERT INTO {topo_schema}.dirty_face (id, map_layer)
   SELECT

--- a/mapboard/topology_manager/fixtures/06-polygon-triggers.sql
+++ b/mapboard/topology_manager/fixtures/06-polygon-triggers.sql
@@ -5,7 +5,10 @@ SELECT ml.id
 FROM {data_schema}.map_layer ml,
      {data_schema}.polygon_type pt
   WHERE ml.id = $1.map_layer
-    AND ml.composited_from IS NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM {data_schema}.map_layer_composition m
+      WHERE m.parent_id = ml.id
+    )
     AND pt.id = $1.type
     AND coalesce(pt.topological, true)
     AND ml.topological;

--- a/mapboard/topology_manager/fixtures/07-get-adjacent-faces.sql
+++ b/mapboard/topology_manager/fixtures/07-get-adjacent-faces.sql
@@ -207,17 +207,29 @@ BEGIN
     _niter := _niter + 1;
   END LOOP;
 
+  -- A temp table carries no statistics, so without this the planner takes
+  -- `_component` for a default-sized relation and drives the join from the wrong
+  -- side -- scanning all of `map_face` to keep a handful of rows.
+  ANALYZE _component;
+
   RETURN QUERY
   SELECT
     (SELECT array_agg(face_id) FROM _component) faces,
     coalesce((
+      -- Driven from the component, with the map_face topogeometry layer pinned:
+      -- a face's `relation` rows span every layer (its map areas, its parts, its
+      -- map_face in each layer), and all but one layer's worth are probed for
+      -- nothing.
       SELECT array_agg(DISTINCT f.id)
-      FROM {topo_schema}.map_face f
+      FROM _component c
       JOIN {topo_schema}.relation r
-        ON (f.topo).id = r.topogeo_id AND r.layer_id = (f.topo).layer_id
-      WHERE r.element_id IN (SELECT face_id FROM _component)
-        AND r.element_type = 3
-        AND f.map_layer = _map_layer
+        ON r.element_id = c.face_id
+       AND r.element_type = 3
+       AND r.layer_id = {topo_schema}.__map_face_layer_id()
+      JOIN {topo_schema}.map_face f
+        ON (f.topo).id = r.topogeo_id
+       AND (f.topo).layer_id = r.layer_id
+      WHERE f.map_layer = _map_layer
     ), ARRAY[]::integer[]) existing_map_faces,
     _niter niter,
     _map_layer map_layer;

--- a/mapboard/topology_manager/fixtures/07-get-adjacent-faces.sql
+++ b/mapboard/topology_manager/fixtures/07-get-adjacent-faces.sql
@@ -208,6 +208,70 @@ END;
 $$ LANGUAGE plpgsql;
 
 
+/** Dissolve every dirty face in a layer, one component at a time, server-side.
+
+  The same expansion `dissolve_component` performs -- this only moves the *loop*
+  into the database. That matters because the caller was making one round trip per
+  dirty face, and dirty sets run to tens of thousands: a third of a real topology's
+  faces or more after a bulk update. Round-tripping each one left the database idle
+  waiting on the client for a third of its time.
+
+  Deliberately not whole-layer label propagation over `joinable_face_edges`, which
+  would converge in as many iterations as the graph is wide -- a component spanning
+  a continent is thousands of hops. Per-component BFS stays proportional to the
+  component.
+
+  `_max_groups` bounds how many components one call returns, so the caller can
+  still persist and checkpoint in batches. Persisting unmarks those faces, so the
+  next call simply sees a smaller dirty set. NULL means "all of them".
+*/
+CREATE OR REPLACE FUNCTION {topo_schema}.dissolve_groups(
+  _map_layer integer,
+  _barrier_layers integer[] DEFAULT ARRAY[]::integer[],
+  _max_groups integer DEFAULT NULL
+)
+RETURNS TABLE (faces integer[], existing_map_faces integer[], niter integer, map_layer integer)
+AS $$
+DECLARE
+  _seed integer;
+  _groups integer := 0;
+  _r record;
+BEGIN
+  -- Faces already claimed by a component returned from *this* call. A separate
+  -- name from `dissolve_component`'s scratch sets, which it truncates per call.
+  CREATE TEMP TABLE IF NOT EXISTS _claimed (face_id integer PRIMARY KEY);
+  TRUNCATE _claimed;
+
+  FOR _seed IN
+    SELECT d.id
+    FROM {topo_schema}.dirty_face d
+    WHERE d.map_layer = _map_layer
+    ORDER BY d.id
+  LOOP
+    EXIT WHEN _max_groups IS NOT NULL AND _groups >= _max_groups;
+    -- Another seed already pulled this face into its component.
+    CONTINUE WHEN EXISTS (
+      SELECT 1 FROM _claimed c WHERE c.face_id = _seed
+    );
+
+    SELECT * INTO _r
+    FROM {topo_schema}.dissolve_component(_seed, _map_layer, _barrier_layers);
+
+    INSERT INTO _claimed (face_id)
+    SELECT unnest(_r.faces)
+    ON CONFLICT DO NOTHING;
+
+    faces := _r.faces;
+    existing_map_faces := _r.existing_map_faces;
+    niter := _r.niter;
+    map_layer := _map_layer;
+    _groups := _groups + 1;
+    RETURN NEXT;
+  END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+
 /** Get faces that can be dissolved into a given map layer */
 CREATE OR REPLACE FUNCTION {topo_schema}.adjacent_faces(
   face_id integer,

--- a/mapboard/topology_manager/fixtures/07-get-adjacent-faces.sql
+++ b/mapboard/topology_manager/fixtures/07-get-adjacent-faces.sql
@@ -120,7 +120,11 @@ Membership is held in indexed temp tables so large components stay efficient. */
 CREATE OR REPLACE FUNCTION {topo_schema}.dissolve_component(
   _seed integer,
   _map_layer integer,
-  _barrier_layers integer[] DEFAULT ARRAY[]::integer[]
+  _barrier_layers integer[] DEFAULT ARRAY[]::integer[],
+  -- Read joinability from `_layer_identity` rather than calling
+  -- `faces_are_joinable` per edge. Only `dissolve_groups` sets this, because only
+  -- it populates the cache; a standalone caller keeps the per-edge path.
+  _use_identity_cache boolean DEFAULT false
 )
 RETURNS TABLE (faces integer[], existing_map_faces integer[], niter integer, map_layer integer)
 AS $$
@@ -134,6 +138,12 @@ BEGIN
   CREATE TEMP TABLE IF NOT EXISTS _component     (face_id integer PRIMARY KEY);
   CREATE TEMP TABLE IF NOT EXISTS _frontier      (face_id integer PRIMARY KEY);
   CREATE TEMP TABLE IF NOT EXISTS _frontier_next (face_id integer PRIMARY KEY);
+  -- Populated per layer by `dissolve_groups`; created here so the frontier query
+  -- plans whether or not the cache is in use.
+  CREATE TEMP TABLE IF NOT EXISTS _layer_identity (
+    face_id integer PRIMARY KEY,
+    identity text
+  );
   TRUNCATE _component, _frontier, _frontier_next;
 
   INSERT INTO _component VALUES (_seed);
@@ -173,12 +183,19 @@ BEGIN
       WHERE c.face_id IS NULL
       GROUP BY fe.edge_id, fe.left_face, fe.right_face, fe.opp_face
     ) j
+    LEFT JOIN _layer_identity il ON _use_identity_cache AND il.face_id = j.left_face
+    LEFT JOIN _layer_identity ir ON _use_identity_cache AND ir.face_id = j.right_face
     WHERE (
             NOT (j.edge_layers && _constraining)
          OR array_length(j.edge_layers, 1) = 0
          OR array_length(_constraining, 1) = 0
           )
-       OR {topo_schema}.faces_are_joinable(j.left_face, j.right_face, _map_layer);
+       OR CASE
+            WHEN _use_identity_cache
+              THEN il.identity IS NOT DISTINCT FROM ir.identity
+            ELSE {topo_schema}.faces_are_joinable(
+                   j.left_face, j.right_face, _map_layer)
+          END;
 
     GET DIAGNOSTICS _added = ROW_COUNT;
     EXIT WHEN _added = 0;
@@ -236,11 +253,35 @@ DECLARE
   _seed integer;
   _groups integer := 0;
   _r record;
+  _cached boolean := {bulk_identity};
 BEGIN
   -- Faces already claimed by a component returned from *this* call. A separate
   -- name from `dissolve_component`'s scratch sets, which it truncates per call.
   CREATE TEMP TABLE IF NOT EXISTS _claimed (face_id integer PRIMARY KEY);
   TRUNCATE _claimed;
+
+  /* Resolve every face's identity for this layer once.
+
+     `faces_are_joinable` is evaluated per candidate edge, so without this each
+     face's identity is re-resolved once per incident edge -- around six times
+     over in a planar graph, and twice that because BFS reaches each edge from
+     both ends. Where the strategy offers a set-oriented form, the whole layer
+     costs about as much as a few hundred individual lookups.
+
+     Only strategies that opt in have `resolve_layer_identity`; the rest keep the
+     per-edge path, which is what `search` wants anyway -- its `faces_are_joinable`
+     is a no-op, so there is nothing to cache. */
+  CREATE TEMP TABLE IF NOT EXISTS _layer_identity (
+    face_id integer PRIMARY KEY,
+    identity text
+  );
+  IF _cached THEN
+    TRUNCATE _layer_identity;
+    INSERT INTO _layer_identity (face_id, identity)
+    SELECT face_id, identity
+    FROM {topo_schema}.resolve_layer_identity(_map_layer);
+    ANALYZE _layer_identity;
+  END IF;
 
   FOR _seed IN
     SELECT d.id
@@ -255,7 +296,8 @@ BEGIN
     );
 
     SELECT * INTO _r
-    FROM {topo_schema}.dissolve_component(_seed, _map_layer, _barrier_layers);
+    FROM {topo_schema}.dissolve_component(
+      _seed, _map_layer, _barrier_layers, _cached);
 
     INSERT INTO _claimed (face_id)
     SELECT unnest(_r.faces)

--- a/mapboard/topology_manager/fixtures/07-get-adjacent-faces.sql
+++ b/mapboard/topology_manager/fixtures/07-get-adjacent-faces.sql
@@ -54,16 +54,16 @@ CREATE OR REPLACE FUNCTION {topo_schema}.layers_are_joinable(
 RETURNS boolean
 AS $$
 DECLARE
-  boundary_layers_with_parents integer[];
+  constraining integer[];
 BEGIN
-  boundary_layers_with_parents := array(
-    SELECT DISTINCT ON (id) {topo_schema}.parent_map_layers(lyr.id) AS id
+  constraining := array(
+    SELECT DISTINCT ON (id) {topo_schema}.constraining_layers(lyr.id) AS id
     FROM unnest(boundary_layers) AS lyr(id)
   );
 
-  RETURN NOT (edge_layers && boundary_layers_with_parents)
+  RETURN NOT (edge_layers && constraining)
       OR array_length(edge_layers, 1) = 0
-      OR array_length(boundary_layers_with_parents, 1) = 0;
+      OR array_length(constraining, 1) = 0;
 END;
 $$ LANGUAGE plpgsql;
 
@@ -127,7 +127,7 @@ AS $$
 DECLARE
   _added integer;
   _niter integer := 0;
-  _boundary_layers_with_parents integer[];
+  _constraining integer[];
 BEGIN
   -- Session-scoped scratch sets, reused across calls (the caller commits per
   -- component, so deliberately no ON COMMIT DROP).
@@ -138,10 +138,10 @@ BEGIN
 
   INSERT INTO _component VALUES (_seed);
   INSERT INTO _frontier  VALUES (_seed);
-  _boundary_layers_with_parents := array(
+  _constraining := array(
     SELECT DISTINCT p.id
     FROM unnest(ARRAY[_map_layer]::integer[] || _barrier_layers) AS lyr(id)
-    CROSS JOIN LATERAL {topo_schema}.parent_map_layers(lyr.id) AS p(id)
+    CROSS JOIN LATERAL {topo_schema}.constraining_layers(lyr.id) AS p(id)
   );
 
   LOOP
@@ -174,9 +174,9 @@ BEGIN
       GROUP BY fe.edge_id, fe.left_face, fe.right_face, fe.opp_face
     ) j
     WHERE (
-            NOT (j.edge_layers && _boundary_layers_with_parents)
+            NOT (j.edge_layers && _constraining)
          OR array_length(j.edge_layers, 1) = 0
-         OR array_length(_boundary_layers_with_parents, 1) = 0
+         OR array_length(_constraining, 1) = 0
           )
        OR {topo_schema}.faces_are_joinable(j.left_face, j.right_face, _map_layer);
 

--- a/mapboard/topology_manager/fixtures/08-linework-notify.sql
+++ b/mapboard/topology_manager/fixtures/08-linework-notify.sql
@@ -52,7 +52,7 @@ BEGIN
   WHERE id = ANY(__map_layers);
 
   -- If all of the map layers are composite, set the composite flag
-  SELECT bool_and(composited_from IS NOT NULL)
+  SELECT bool_and({data_schema}.is_composite_layer(id))
   INTO __composite
   FROM {data_schema}.map_layer
   WHERE id = ANY(__map_layers);

--- a/mapboard/topology_manager/fixtures/09-topology-notify.sql
+++ b/mapboard/topology_manager/fixtures/09-topology-notify.sql
@@ -66,7 +66,7 @@ BEGIN
   WHERE id = ANY(__map_layers);
 
   -- If all of the map layers are composite, set the composite flag
-  SELECT bool_and(composited_from IS NOT NULL)
+  SELECT bool_and({data_schema}.is_composite_layer(id))
   INTO __composite
   FROM {data_schema}.map_layer
   WHERE id = ANY(__map_layers);

--- a/mapboard/topology_manager/test_helpers.py
+++ b/mapboard/topology_manager/test_helpers.py
@@ -185,10 +185,9 @@ def create_composite_layer(
             "name",
             parent,
             topological,
-            editable,
-            composited_from
+            editable
         )
-        VALUES (:name, :parent, :topological, :editable, :composited_from)
+        VALUES (:name, :parent, :topological, :editable)
         RETURNING id
         """,
         {
@@ -196,9 +195,18 @@ def create_composite_layer(
             "topological": True,
             "editable": False,
             "parent": parent,
-            "composited_from": layers,
         },
     ).scalar()
+    # Members are bottom-to-top, matching the order the former `composited_from`
+    # array held; priority is the 1-based position, so the last member wins.
+    for priority, member in enumerate(layers, start=1):
+        db.run_query(
+            """
+            INSERT INTO {data_schema}.map_layer_composition (parent_id, member_id, priority)
+            VALUES (:parent_id, :member_id, :priority)
+            """,
+            {"parent_id": lyr, "member_id": member, "priority": priority},
+        )
     return lyr
 
 

--- a/tests/map_areas/fixtures/01-create-tables.sql
+++ b/tests/map_areas/fixtures/01-create-tables.sql
@@ -40,7 +40,7 @@ CREATE OR REPLACE FUNCTION map_bounds_topology.get_topological_map_layer(_line m
 SELECT ml.id
 FROM map_bounds.map_layer ml
 WHERE ml.id = $1.map_layer
-  AND ml.composited_from IS NULL
+  AND NOT map_bounds.is_composite_layer(ml.id)
   AND ml.topological;
 $$ LANGUAGE SQL IMMUTABLE;
 
@@ -76,15 +76,23 @@ VALUES
 ON CONFLICT (slug) DO NOTHING;
 
 /** Composite compilations */
-INSERT INTO map_bounds.map_layer (slug, name, bounds, topological, editable, composited_from)
+INSERT INTO map_bounds.map_layer (slug, name, bounds, topological, editable)
 VALUES
  ('carto-small', 'Carto small',
-  ST_Multi(ST_MakeEnvelope(-180, -90, 180, 90, 4326)), true, false,
-  ARRAY[map_bounds.layer_id('tiny'), map_bounds.layer_id('small')]),
+  ST_Multi(ST_MakeEnvelope(-180, -90, 180, 90, 4326)), true, false),
  ('carto-medium', 'Carto medium',
-  ST_Multi(ST_MakeEnvelope(-180, -90, 180, 90, 4326)), true, false,
-  ARRAY[map_bounds.layer_id('small'), map_bounds.layer_id('medium')]),
+  ST_Multi(ST_MakeEnvelope(-180, -90, 180, 90, 4326)), true, false),
  ('carto-large', 'Carto large',
-  ST_Multi(ST_MakeEnvelope(-180, -90, 180, 90, 4326)), true, false,
-  ARRAY[map_bounds.layer_id('medium'), map_bounds.layer_id('large')])
+  ST_Multi(ST_MakeEnvelope(-180, -90, 180, 90, 4326)), true, false)
 ON CONFLICT (slug) DO NOTHING;
+
+/** Membership: priority ascends bottom-to-top, so the second member wins. */
+INSERT INTO map_bounds.map_layer_composition (parent_id, member_id, priority)
+VALUES
+ (map_bounds.layer_id('carto-small'),  map_bounds.layer_id('tiny'),   1),
+ (map_bounds.layer_id('carto-small'),  map_bounds.layer_id('small'),  2),
+ (map_bounds.layer_id('carto-medium'), map_bounds.layer_id('small'),  1),
+ (map_bounds.layer_id('carto-medium'), map_bounds.layer_id('medium'), 2),
+ (map_bounds.layer_id('carto-large'),  map_bounds.layer_id('medium'), 1),
+ (map_bounds.layer_id('carto-large'),  map_bounds.layer_id('large'),  2)
+ON CONFLICT (parent_id, member_id) DO NOTHING;

--- a/tests/map_areas/fixtures/03-identity-management.sql
+++ b/tests/map_areas/fixtures/03-identity-management.sql
@@ -34,7 +34,9 @@ SELECT
   map_id
 FROM map_bounds_topology.relation r
 JOIN map_bounds.map_area f
+  -- A topogeometry id is only unique within a layer.
   ON (f.topo).id = r.topogeo_id
+ AND (f.topo).layer_id = r.layer_id
  AND f.map_layer = $2
 JOIN map_bounds.map_priority mc
   ON mc.map_id = f.id


### PR DESCRIPTION
Main PR to implement a more streamlined composite layers approach. This is useful for map compositing and overlayed map layers (e.g., bedrock and surficial map units)